### PR TITLE
Drop unneeded and inconsistent working_directory specification

### DIFF
--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -109,7 +109,6 @@ jobs:
           steps:
             - run: echo "overcommit only runs on main branch"
   build:
-    working_directory: ~/{{cookiecutter.project_slug}}
     docker:
       - image: apiology/circleci:latest
     steps:


### PR DESCRIPTION
This seems to have been confusing npm installs and causing mildly
different results in the lock files.

See https://app.circleci.com/pipelines/github/apiology/opener_for_asana?branch=debug