### PR TITLE
Allow for/of loops in eslint rules

### DIFF
--- a/{{cookiecutter.project_slug}}/.eslintrc.yml
+++ b/{{cookiecutter.project_slug}}/.eslintrc.yml
@@ -36,3 +36,18 @@ rules:
   strict:
     - error
     - safe
+  # for of rules are not relevant when we are only extending modern browsers
+  #
+  # https://github.com/airbnb/javascript/issues/1271#issuecomment-548688952
+  no-restricted-syntax:
+    - error
+    - selector: 'ForInStatement'
+      message: "for..in loops iterate over the entire prototype chain, which is virtually never what you want.\
+        Use Object.{keys,values,entries}, and iterate over the resulting array."
+    # - selector: 'ForOfStatement'
+    #   message: 'iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow \
+    #    them. Separately, loops should be avoided in favor of array iterations.'
+    - selector: 'LabeledStatement'
+      message: 'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.'
+    - selector: 'WithStatement'
+      message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.'


### PR DESCRIPTION
AirBNB's style guide for/of loop rules are not relevant when we are only extending modern browsers