### PR TITLE
Drop redundant include specification in tsconfig.json

### DIFF
--- a/{{cookiecutter.project_slug}}/tsconfig.json
+++ b/{{cookiecutter.project_slug}}/tsconfig.json
@@ -10,8 +10,5 @@
     "moduleResolution": "node16",
     "lib": ["es2015", "dom"],
     "sourceMap": true
-  },
-  "include": [
-    "src"
-  ]
+  }
 }


### PR DESCRIPTION
This will allow this tsconfig.json to be a base configuration that others specialize from