### PR TITLE
Opt into new_memberships deprecation in Asana API

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -20,7 +20,7 @@ repl: ## Bring up an interactive JavaScript prompt
 	@echo "const asana = require('asana');"
 	@echo "const clientOptions = {"
 	@echo "    defaultHeaders: {"
-	@echo "      'Asana-Enable': 'new_user_task_lists,new_project_templates',"
+	@echo "      'Asana-Enable': 'new_user_task_lists,new_project_templates,new_memberships',"
 	@echo "    },"
 	@echo "};"
 	@echo "const asanaAccessToken = process.env.ASANA_API_TOKEN;"


### PR DESCRIPTION
> This request is affected by the "new_memberships" deprecation. Please visit this url for more info: https://forum.asana.com/t/upcoming-changes-that-impact-getting-and-setting-memberships-and-access-levels/232106?u

> Adding "new_memberships" to your "Asana-Enable" or "Asana-Disable" header will opt in/out to this deprecation and suppress this warning.