### PR TITLE
Scope yarn immutable-installs override to cold bake; drop redundant version pin

### DIFF
--- a/{{cookiecutter.project_slug}}/fix.sh
+++ b/{{cookiecutter.project_slug}}/fix.sh
@@ -67,9 +67,17 @@ ensure_node_versions() {
 
 ensure_yarn() {
   npm install -g corepack
-  yarn set version 4.9.2 </dev/null
+  # package.json's "packageManager" field pins the exact Yarn version;
+  # Corepack reads it automatically, so no explicit `yarn set version` here.
   touch yarn.lock
-  YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
+  if [ -s yarn.lock ]
+  then
+    yarn install
+  else
+    # Fresh cookiecutter bake: no committed lockfile yet, so it must be
+    # generated here rather than enforcing immutability against it.
+    YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
+  fi
 }
 
 ensure_npm_modules() {


### PR DESCRIPTION
## Summary
- `ensure_yarn()` in `fix.sh` unconditionally set `YARN_ENABLE_IMMUTABLE_INSTALLS=false` before every `yarn install`, disabling Yarn's built-in check that a checked-in `yarn.lock` matches `package.json`. That check exists specifically to catch lockfile drift in CI - disabling it always meant a PR that changed `package.json` without regenerating/committing `yarn.lock` would silently get a regenerated lockfile in CI instead of failing loudly.
- The override is only actually needed once: on a fresh cookiecutter bake, where no `yarn.lock` is committed yet (the template doesn't track one) and it must be generated from scratch. Every other run - which is the common case, real CI on an already-baked repo - should keep immutability enforced.
- Also dropped the explicit `yarn set version 4.9.2 </dev/null`: `package.json` already declares `"packageManager": "yarn@4.9.2"`, which Corepack reads automatically once `corepack` is installed, so the explicit pin in `fix.sh` was redundant (and needed the `</dev/null` workaround only because of that explicit invocation).

## Test plan
- [x] `pytest tests/test_bake_project.py -v` passes (2/2) - fresh bake still succeeds, exercising the now-scoped non-immutable branch
- [x] Manually reran `fix.sh`'s yarn step a second time against an already-baked project with a valid `yarn.lock`: immutable install succeeds, no unnecessary reinstall
- [x] Manually added an unresolved dependency to `package.json` without updating `yarn.lock` and reran: now correctly fails with Yarn's `YN0028` frozen-lockfile error instead of silently mutating the lockfile - confirms the safety net is restored for the case that matters
